### PR TITLE
Francescomiliani patch 1 fix sender amount recovering on event

### DIFF
--- a/packages/anonymous.js/src/client.js
+++ b/packages/anonymous.js/src/client.js
@@ -63,6 +63,9 @@ class Client {
                                 });
                                 const parameters = web3.eth.abi.decodeParameters(inputs, "0x" + transaction.input.slice(10));
                                 const value = utils.readBalance(parameters['C'][i], parameters['D'], account.keypair['x']);
+                                // INFO: Only the receiver of the transfer will have a value greather than 0
+                                // the sender that will have a value less than 0 that is -value
+                                // Every other party will have a value equal to 0
                                 if (value > 0) {
                                     account._state.pending += value;
                                     console.log("Transfer of " + value + " received! Balance now " + (account._state.available + account._state.pending) + ".");

--- a/packages/anonymous.js/src/utils/utils.js
+++ b/packages/anonymous.js/src/utils/utils.js
@@ -32,10 +32,13 @@ utils.readBalance = (CL, CR, x) => {
     CL = bn128.deserialize(CL);
     CR = bn128.deserialize(CR);
     const gB = CL.add(CR.mul(x.redNeg()));
+    const gB_neg = CL.add(CR.mul(x.redNeg())).neg();
+    // Should be null for [null,null] for decoys,  not processed for sender in the client example
 
     let accumulator = bn128.zero;
     for (let i = 0; i < bn128.B_MAX; i++) {
         if (accumulator.eq(gB)) return i;
+        if (accumulator.eq(gB_neg)) return -i;
         accumulator = accumulator.add(bn128.curve.g);
     }
 };


### PR DESCRIPTION
Fixes the infinite loop bug in calculating the value for the transfer sender when receiving the TransferOccured event produced as a result of a transfer.

In detail: during the transfer all listening clients receive and process the event, and only the involved parties will go to decrypt the value with secret x.

The bug consists of an infinite loop in the calculation of the value in the client of the sender of the transfer since the value to look for is negative, not positive, because it would never be found by blocking the application.

This bug is not apparent with Truffle since the statement in the client.js file.

event.returnValues['parties'] === null

returns in the sender client event.

In case the application is integrated into serious applications that listen for events and the clients are distributed son multiple machines, the problem becomes serious and very relevant.

Fixes the infinite loop bug in calculating the value for the transfer sender when receiving the TransferOccured event produced as a result of a transfer.

In detail: during the transfer all listening clients receive and process the event, and only the involved parties will go to decrypt the value with secret x.

The bug consists of an infinite loop in the calculation of the value in the client of the sender of the transfer since the value to look for is negative, not positive, because it would never be found by blocking the application.

This bug is not apparent with Truffle since the statement in the client.js file.

event.returnValues['parties'] === null

returns in the sender client event.

In case the application is integrated into serious applications that listen for events and the clients are distributed son multiple machines, the problem becomes serious and very relevant.

Solution: calculate the gB_neg that negative corresponding to - value, as well